### PR TITLE
receiver_raw should look for headers in pg_config --includedir

### DIFF
--- a/receiver_raw/Makefile
+++ b/receiver_raw/Makefile
@@ -5,3 +5,5 @@ SHLIB_LINK = $(libpq)
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
++CC+=-I $(shell $(PG_CONFIG) --includedir)
+


### PR DESCRIPTION
@michaelpq kudos on the great work.

This was needed to get get ``receiver_raw`` to compile on Ubuntu 14.04 with PostgreSQL 9.4.

Without adding this line ``libpq-fe.h`` could not be found despite being in the --include-dir.

I've compiled many plugins without issue on the same machine; including several of yours, not sure what's different with this one.

Thanks,
Jeff
