### PR TITLE
Fix log_min_messages for "LOG" messages 

### DIFF
--- a/jsonlog/jsonlog.c
+++ b/jsonlog/jsonlog.c
@@ -218,7 +218,7 @@ appendJSONLiteral(StringInfo buf, char *key, char *value, bool is_comma)
 static bool
 is_log_level_output(int elevel, int log_min_level)
 {
-	if (elevel == LOG || elevel == LOG_SERVER_ONLY)
+	if (elevel == LOG || elevel == COMMERROR)
 	{
 		if (log_min_level == LOG || log_min_level <= ERROR)
 			return true;

--- a/jsonlog/jsonlog.c
+++ b/jsonlog/jsonlog.c
@@ -208,6 +208,35 @@ appendJSONLiteral(StringInfo buf, char *key, char *value, bool is_comma)
 }
 
 /*
+ * is_log_level_output -- is elevel logically >= log_min_level?
+ *
+ * We use this for tests that should consider LOG to sort out-of-order,
+ * between ERROR and FATAL.  Generally this is the right thing for testing
+ * whether a message should go to the postmaster log, whereas a simple >=
+ * test is correct for testing whether the message should go to the client.
+ */
+static bool
+is_log_level_output(int elevel, int log_min_level)
+{
+	if (elevel == LOG || elevel == LOG_SERVER_ONLY)
+	{
+		if (log_min_level == LOG || log_min_level <= ERROR)
+			return true;
+	}
+	else if (log_min_level == LOG)
+	{
+		/* elevel != LOG */
+		if (elevel >= FATAL)
+			return true;
+	}
+	/* Neither is LOG */
+	else if (elevel >= log_min_level)
+		return true;
+
+	return false;
+}
+
+/*
  * write_jsonlog
  * Write logs in json format.
  */
@@ -227,7 +256,7 @@ write_jsonlog(ErrorData *edata)
 	 * Nothing to do if log message has a severity lower than the minimum
 	 * wanted.
 	 */
-	if (edata->elevel < log_min_messages)
+	if (!is_log_level_output(edata->elevel, log_min_messages))
 		return;
 
 	initStringInfo(&buf);


### PR DESCRIPTION
Postgres's interpretation of LOG level messages is ... curious. They're treated as between DEBUG1 and INFO for the client but as equal to ERROR for the server log. Copy the function from elog.c to implement this.