### PR TITLE
Fix timestamps

### DIFF
--- a/jsonlog/jsonlog.c
+++ b/jsonlog/jsonlog.c
@@ -169,7 +169,7 @@ setup_formatted_log_time(void)
 	 */
 	pg_strftime(log_time, LOG_TIMESTAMP_LEN,
 				/* leave room for milliseconds... */
-				"%Y-%m-%d %H:%M:%S	 %Z",
+				"%Y-%m-%dT%H:%M:%S.000%z",
 				pg_localtime(&stamp_time, log_timezone));
 
 	/* 'paste' milliseconds into place... */

--- a/jsonlog/jsonlog.c
+++ b/jsonlog/jsonlog.c
@@ -236,8 +236,7 @@ write_jsonlog(ErrorData *edata)
 	appendStringInfoChar(&buf, '{');
 
 	/* Timestamp */
-	if (log_time[0] == '\0')
-		setup_formatted_log_time();
+    setup_formatted_log_time();
 	appendJSONLiteral(&buf, "timestamp", log_time, true);
 
 	/* Username */


### PR DESCRIPTION
It looks like at some point this code has been through an editor that replaced strings of repeated spaces with tabs even if they're inside quoted strings. That broke the date formatting. Also, may as well use ISO standard timestamps in JSON rather than Postgres style timestamps....

Also, it seems some code was lifted from elog.c without overzealously and as a result the timestamp was only being formatted once. Every log entry then had the same timestamp forevermore....