### PR TITLE
Updated code to allow passwordcheck_extra compile for PG9 as well

### DIFF
--- a/passwordcheck_extra/Makefile
+++ b/passwordcheck_extra/Makefile
@@ -11,5 +11,9 @@ REGRESS = passwordcheck_extra
 # SHLIB_LINK = -lcrack
 
 PG_CONFIG = pg_config
+PG_MAJOR_VERSION := $(word 2, $(subst ., ,$(shell $(PG_CONFIG) --version)))
+ifeq ($(PG_MAJOR_VERSION),9)
+  PG_CPPFLAGS = -DOLD_PASSWORD_TYPE
+endif
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)

--- a/passwordcheck_extra/passwordcheck_extra.c
+++ b/passwordcheck_extra/passwordcheck_extra.c
@@ -21,7 +21,15 @@
 
 #include "commands/user.h"
 #include "fmgr.h"
-#include "common/md5.h"
+
+#ifndef OLD_PASSWORD_TYPE 
+    #include "common/md5.h"
+#else
+    #include "libpq/md5.h"
+    #include "commands/user.h"
+    typedef int PasswordType;
+#endif
+
 #include "lib/stringinfo.h"
 #include "utils/guc.h"
 


### PR DESCRIPTION
Hi michael, 

Appreciate your work in passwordcheck_extra. This is useful for a customer scenario who wanted to force a password policy and the contrib passwordcheck was not good enough.
Have made small changes in Makefile and passwordcheck.c to allow them to compile on version 9 as well.
Have executed regression on both 9.6 and 10, and they are passing. 
Since this is my first contribution in postgres - apologies for silly mistakes and looking forward for feedback which i will be happy to fix to make this available for all.

Best Regards
Pankaj Kapoor