### PR TITLE
Fix symbols' visibility for Postgres 16~.

### DIFF
--- a/count_relations/count_relations.c
+++ b/count_relations/count_relations.c
@@ -34,7 +34,7 @@
 PG_MODULE_MAGIC;
 
 void _PG_init(void);
-void count_relations_main(Datum main_arg) pg_attribute_noreturn();
+PGDLLEXPORT void count_relations_main(Datum main_arg) pg_attribute_noreturn();
 
 static volatile sig_atomic_t got_sigterm = false;
 

--- a/hello_notify/hello_notify.c
+++ b/hello_notify/hello_notify.c
@@ -32,7 +32,7 @@
 PG_MODULE_MAGIC;
 
 void _PG_init(void);
-void hello_notify_main(Datum main_arg) pg_attribute_noreturn();
+PGDLLEXPORT void hello_notify_main(Datum main_arg) pg_attribute_noreturn();
 
 /* Worker name */
 static const char *hello_notify_name = "hello_notify";

--- a/hello_signal/hello_signal.c
+++ b/hello_signal/hello_signal.c
@@ -26,7 +26,7 @@ PG_MODULE_MAGIC;
 
 /* Entry point of library loading */
 void _PG_init(void);
-void hello_main(Datum main_arg) pg_attribute_noreturn();
+PGDLLEXPORT void hello_main(Datum main_arg) pg_attribute_noreturn();
 
 /* SIGTERM handling */
 static volatile sig_atomic_t got_sigterm = false;
@@ -100,7 +100,7 @@ _PG_init(void)
 	BackgroundWorker worker;
 
 	MemSet(&worker, 0, sizeof(BackgroundWorker));
-	worker.bgw_flags = 0;
+	worker.bgw_flags = BGWORKER_SHMEM_ACCESS;
 	worker.bgw_start_time = BgWorkerStart_PostmasterStart;
 	snprintf(worker.bgw_library_name, BGW_MAXLEN, "hello_signal");
 	snprintf(worker.bgw_function_name, BGW_MAXLEN, "hello_main");

--- a/hello_world/hello_world.c
+++ b/hello_world/hello_world.c
@@ -26,7 +26,7 @@ PG_MODULE_MAGIC;
 /* Entry point of library loading */
 void _PG_init(void);
 /* Main loop of process */
-void hello_main(Datum main_arg) pg_attribute_noreturn();
+PGDLLEXPORT void hello_main(Datum main_arg) pg_attribute_noreturn();
 
 /* Signal handling */
 static volatile sig_atomic_t got_sigterm = false;

--- a/kill_idle/kill_idle.c
+++ b/kill_idle/kill_idle.c
@@ -31,7 +31,7 @@ PG_MODULE_MAGIC;
 
 /* Entry point of library loading */
 void _PG_init(void);
-void kill_idle_main(Datum main_arg) pg_attribute_noreturn();
+PGDLLEXPORT void kill_idle_main(Datum main_arg) pg_attribute_noreturn();
 
 /* Signal handling */
 static volatile sig_atomic_t got_sigterm = false;

--- a/receiver_raw/receiver_raw.c
+++ b/receiver_raw/receiver_raw.c
@@ -37,7 +37,7 @@ PG_MODULE_MAGIC;
 
 /* Entry point of library loading */
 void _PG_init(void);
-void receiver_raw_main(Datum main_arg);
+PGDLLEXPORT void receiver_raw_main(Datum main_arg);
 
 /* Signal handling */
 static volatile sig_atomic_t got_sigterm = false;


### PR DESCRIPTION
- This patch helps add 'PGDLLEXPORT' to background worker entries in this repo.

  The symbols' visibility are hidden in extension libraries by default in Postgres 16~.
  See: https://github.com/postgres/postgres/commit/089480c077056fc20fa8d8f5a3032a9dcf5ed812

- This patch also adds 'BGWORKER_SHMEM_ACCESS' to hello_signal bgw's flag, since it requires it.

P.S. I only checked the symbols' visibility for extensions who launch bgworkers in this repo.

